### PR TITLE
Add automatic exploitdb installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ POC Seeker script is written in Bash and relies on several (usually pre-installe
     ```
 
 - **searchsploit**
-  - **Installation**: `searchsploit` is part of the Exploit Database repository. It can be installed on Debian-based systems by installing the `exploitdb` package or via a direct clone from its GitHub repository. For a direct installation, you can use:
+  - **Installation**: `searchsploit` is part of the Exploit Database repository. It can be installed on Debian-based systems by installing the `exploitdb` package or via a direct clone from its GitHub repository. The script will also attempt to install it automatically if missing. For a manual installation, you can use:
     ```bash
     sudo git clone https://gitlab.com/exploit-database/exploitdb.git /opt/exploitdb
     sudo ln -sf /opt/exploitdb/searchsploit /usr/local/bin/searchsploit

--- a/poc-seeker.sh
+++ b/poc-seeker.sh
@@ -161,6 +161,31 @@ function check_curl_features()
   fi
 }
 
+function ensure_exploitdb_installed()
+{
+  if ! command -v searchsploit >/dev/null; then
+    yellow "searchsploit not found, attempting to install exploitdb ...\n"
+    if command -v apt-get >/dev/null; then
+      sudo apt-get update && sudo apt-get install -y exploitdb
+    elif command -v dnf >/dev/null; then
+      sudo dnf install -y exploitdb
+    elif command -v yum >/dev/null; then
+      sudo yum install -y exploitdb
+    elif command -v pacman >/dev/null; then
+      sudo pacman -Sy --noconfirm exploitdb
+    else
+      red "Failed to find a supported package manager. Please install exploitdb manually.\n"
+      exit 1
+    fi
+    if ! command -v searchsploit >/dev/null; then
+      red "Automatic installation failed. Please install exploitdb manually.\n"
+      exit 1
+    else
+      green "exploitdb installed successfully.\n"
+    fi
+  fi
+}
+
 function check_for_update()
 {
   SCRIPT_RAW_URL="https://raw.githubusercontent.com/0xyassine/poc-seeker/master/poc-seeker.sh"
@@ -526,6 +551,7 @@ function nvd_collect_information()
 logo
 verify_packages
 check_curl_features
+ensure_exploitdb_installed
 
 #IS THE TOOL EXECUTED WITHOUT ANY ARGUEMTNS?
 if [[ $# -eq 0 ]];then


### PR DESCRIPTION
## Summary
- auto-install `exploitdb` if `searchsploit` is missing
- mention this automation in the README

## Testing
- `bash poc-seeker.sh --help | head -n 20` *(fails: `Unable to locate package exploitdb`)*
- `bash -n poc-seeker.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845072763248332a274559211e76bf5